### PR TITLE
/signin -> /login に変更

### DIFF
--- a/app/group/page.js
+++ b/app/group/page.js
@@ -56,7 +56,7 @@ export default function GroupPage() {
           }
         }
       } else {
-        router.push("/signin");
+        router.push("/login");
       }
     });
     return () => unsubscribe();

--- a/app/page.js
+++ b/app/page.js
@@ -63,7 +63,7 @@ export default function Home() {
     const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
       setUser(currentUser || null);
       if (!currentUser) {
-        router.push("/signin");
+        router.push("/login");
       }
     });
     return () => unsubscribe();


### PR DESCRIPTION
対象ページにおいて、 `/signin` になっていたルーティングを `/login` に修正